### PR TITLE
Feature/add nepali locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ GetTimeAgo.setCustomLocaleMessages('en', CustomMessages());
 - Vietnamese
 - Romanian
 - Dutch
+- Nepali
 - Open to accept PR for adding more languages
 
 ## Contributing

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,6 +53,7 @@ const Map<String, String> languageNames = {
   'vi': 'Vietnamese',
   'ro': 'Romanian',
   'nl': 'Dutch',
+  "ne": 'Nepali'
 };
 
 class _GetTimeAgoExampleScreenState extends State<GetTimeAgoExampleScreen> {

--- a/lib/src/messages/languages/ne_msg.dart
+++ b/lib/src/messages/languages/ne_msg.dart
@@ -1,0 +1,43 @@
+import 'package:get_time_ago/get_time_ago.dart';
+
+class NepaliMessages extends Messages {
+  /// Message for approximately 1 day ago. [hours]: The number of hours that have passed (usually 24).
+  @override
+  String dayAgo(int hours) => "एक दिन";
+
+  /// Message when the elapsed time is in days. [days]: The number of days that have passed.
+  @override
+  String daysAgo(int days) => "$days दिन";
+
+  /// Message for approximately 1 hour ago. [minutes]: The number of minutes that have passed (usually 60).
+  @override
+  String hourAgo(int minutes) => "एक घण्टा";
+
+  /// Message when the elapsed time is in hours. [hours]: The number of hours that have passed.
+  @override
+  String hoursAgo(int hours) => "$hours घण्टा";
+
+  /// Message when the elapsed time is less than 15 seconds. [seconds]: The number of seconds that have passed.
+  @override
+  String justNow(int seconds) => "भर्खरै";
+
+  /// Message for approximately 1 minute ago. [minutes]: The number of minutes that have passed (usually 1).
+  @override
+  String minAgo(int minutes) => "एक मिनेट";
+
+  /// Message when the elapsed time is in minutes. [minutes]: The number of minutes that have passed.
+  @override
+  String minsAgo(int minutes) => "$minutes मिनेट";
+
+  /// Prefix added before the time ago message
+  @override
+  String prefixAgo() => "";
+
+  /// Message when the elapsed time is less than a minute. [seconds]: The number of seconds that have passed.
+  @override
+  String secsAgo(int seconds) => "$seconds सेकेन्ड";
+
+  /// Suffix added after the time ago message.
+  @override
+  String suffixAgo() => "अघि";
+}

--- a/lib/src/utils/data.dart
+++ b/lib/src/utils/data.dart
@@ -1,3 +1,5 @@
+import 'package:get_time_ago/src/messages/languages/ne_msg.dart';
+
 import '../messages/languages/ar_msg.dart';
 import '../messages/languages/de_msg.dart';
 import '../messages/languages/en_msg.dart';
@@ -53,5 +55,6 @@ class Data {
     'vi': VietnameseMessages(), // Vietnamese
     'ro': RomanianMessages(), // Romanian
     'nl': DutchMessages(), // Dutch
+    "ne": NepaliMessages(), // Nepali
   };
 }

--- a/test/messages/language/ne_msg_test.dart
+++ b/test/messages/language/ne_msg_test.dart
@@ -1,0 +1,163 @@
+import 'package:get_time_ago/get_time_ago.dart';
+import 'package:get_time_ago/src/messages/languages/ne_msg.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var nepaliMessages = NepaliMessages();
+
+  group("Nepali Message Test", () {
+    test("Just now should return भर्खरै", () {
+      expect(nepaliMessages.justNow(5), "भर्खरै");
+    });
+
+    test("daysAgo should return 1 दिन", () {
+      expect(nepaliMessages.daysAgo(1), "1 दिन");
+    });
+
+    test("dayAgo should return एक दिन", () {
+      expect(nepaliMessages.dayAgo(24), "एक दिन");
+    });
+
+    test("minAgo should return एक मिनेट", () {
+      expect(nepaliMessages.minAgo(1), "एक मिनेट");
+    });
+
+    test("minsAgo should return 10 मिनेट", () {
+      expect(nepaliMessages.minsAgo(10), "10 मिनेट");
+    });
+
+    test("prefixAgo should return empty string", () {
+      expect(nepaliMessages.prefixAgo(), "");
+    });
+
+    test("suffixAgo should return अघि", () {
+      expect(nepaliMessages.suffixAgo(), "अघि");
+    });
+
+    test("secondsAgo should return 20 सेकेन्ड", () {
+      expect(nepaliMessages.secsAgo(20), "20 सेकेन्ड");
+    });
+
+    test('wordSeperator should return " " ', () {
+      expect(nepaliMessages.wordSeparator(), " ");
+    });
+
+    test("hourAgo should return एक घण्टा", () {
+      expect(nepaliMessages.hourAgo(40), "एक घण्टा");
+    });
+
+    test("hoursAgo should return 3 घण्टा", () {
+      expect(nepaliMessages.hoursAgo(3), "3 घण्टा");
+    });
+  });
+
+  // Helper function to get the DateTime relative to now
+  DateTime _getRelativeDateTime(Duration duration) {
+    return DateTime.now().subtract(duration);
+  }
+
+  group("GetTimeAgo with Nepali Locale", () {
+    test("should return भर्खरै for time ellapsed less than 15 seconds", () {
+      final result = GetTimeAgo.parse(
+        _getRelativeDateTime(
+          const Duration(seconds: 0),
+        ),
+        locale: "ne",
+      );
+      expect(result, "भर्खरै");
+    });
+
+    test("should return भर्खरै for time ellapsed less than 15 seconds", () {
+      final result = GetTimeAgo.parse(
+        _getRelativeDateTime(
+          const Duration(seconds: 13),
+        ),
+        locale: "ne",
+      );
+      expect(result, "भर्खरै");
+    });
+
+    test("should return 20 सेकेन्ड अघि for time ellapsed more than 15 seconds",
+        () {
+      final result = GetTimeAgo.parse(
+        _getRelativeDateTime(
+          const Duration(seconds: 25),
+        ),
+        locale: "ne",
+      );
+      expect(result, "25 सेकेन्ड अघि");
+    });
+
+    test("should return एक मिनेट अघि for time 1 min ago", () {
+      final result = GetTimeAgo.parse(
+        _getRelativeDateTime(const Duration(minutes: 1)),
+        locale: "ne",
+      );
+      expect(result, "एक मिनेट अघि");
+    });
+
+    test("should return 2 मिनेट अघिn for time 2 minutes ago", () {
+      final result = GetTimeAgo.parse(
+        _getRelativeDateTime(const Duration(minutes: 2)),
+        locale: "ne",
+      );
+      expect(result, "2 मिनेट अघि");
+    });
+
+    test("should return एक घण्टा अघि for time 1 hour ago", () {
+      final result = GetTimeAgo.parse(
+        _getRelativeDateTime(const Duration(hours: 1)),
+        locale: "ne",
+      );
+
+      expect(result, "एक घण्टा अघि");
+    });
+
+    test("should return 2 घण्टा अघि for time 2 hour ago", () {
+      final result = GetTimeAgo.parse(
+        _getRelativeDateTime(const Duration(hours: 2)),
+        locale: "ne",
+      );
+
+      expect(result, "2 घण्टा अघि");
+    });
+
+    test("should return एक दिन अघि for time 24 hours ago", () {
+      final result = GetTimeAgo.parse(
+        _getRelativeDateTime(
+          const Duration(hours: 24),
+        ),
+        locale: "ne",
+      );
+      expect(result, "एक दिन अघि");
+    });
+
+    test("should return 3 दिन अघि for time 3 day ago", () {
+      final result = GetTimeAgo.parse(
+        _getRelativeDateTime(
+          const Duration(days: 3),
+        ),
+        locale: "ne",
+      );
+      expect(result, "3 दिन अघि");
+    });
+
+    test("should return 7 दिन अघि for time 7 day ago", () {
+      final result = GetTimeAgo.parse(
+        _getRelativeDateTime(
+          const Duration(days: 7),
+        ),
+        locale: "ne",
+      );
+      expect(result, "7 दिन अघि");
+    });
+
+    test("should return formatted data for duration beyond 7 days", () {
+      final result = GetTimeAgo.parse(
+        _getRelativeDateTime(const Duration(days: 8)),
+        locale: "ne",
+      );
+      expect(result, isNot("8 दिन अघि"));
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request Checklist

## What does this PR do?

<h1>Added Nepali locale support to the get_time_ago package.</h1>

<!--

- Adds/improves functionality for localized time-ago formatting
- Fixes bugs or issues
- Adds new features like custom time thresholds, additional languages, etc.
- Optimizes performance or enhances accessibility

-->

## **Checklist**

### Code Changes

- [x] I have added new features to the package (support for nepali language)

### Documentation

- [x] I have updated the README file or relevant documentation with the changes
- [ ] I have added code usage examples or updated existing examples to reflect changes
- [ ] I have updated the package version in the `pubspec.yaml` file

### Testing

**General Tests**

- [x] The package correctly formats time differences into human-readable strings
- [x] The package supports dynamic updates (e.g., changing locales, thresholds)

**Localization**

- [x] The package supports all documented languages
- [x] Custom locales can be added and work as expected
- [x] Language fallback works correctly if a specific locale is missing

**Custom Thresholds**

- [x] Custom time thresholds are applied correctly
- [x] The package handles edge cases like just now, future dates, or extreme past dates

**Error Handling**

- [x] The package handles null or invalid inputs gracefully
- [x] Fallback behavior works for unexpected or incorrect configurations

**Responsiveness**

- [x] The package adapts to time-zone differences accurately
- [x] The formatting responds correctly to locale changes in the app

**Performance**

- [x] The package performs efficiently, even when processing frequent or large updates
- [x] Performance tests show no regressions

### How did you verify your code works?
- I have written unit tests covering the new features
- I ran manual tests to verify time formatting for different locales and thresholds
- I tested with various configurations (custom thresholds, language overrides)
- All tests pass locally (`flutter test`)
![Test Cases](https://github.com/user-attachments/assets/8509a501-3a78-4f8e-ae68-08ab276d9e1f)

https://github.com/user-attachments/assets/79b39a9b-bcea-4e80-88fe-c2ee58e77800



-->
