### PR TITLE
Improving German Message Localization

### DIFF
--- a/lib/src/messages/languages/de_msg.dart
+++ b/lib/src/messages/languages/de_msg.dart
@@ -14,7 +14,7 @@ class GermanMessages implements Messages {
 
   /// Message when the elapsed time is less than 15 seconds.
   @override
-  String justNow(int seconds) => 'vorhin';
+  String justNow(int seconds) => 'gerade';
 
   /// Message for when the elapsed time is less than a minute.
   @override


### PR DESCRIPTION
## What does this PR do?

This PR changes the translation for "just now" from "vorhin" to "gerade". While the translation for both seems to be identical, there's a not insignificant shift in meaning in the German language. "Vorhin" is quite a bit further in the past than "gerade". This past could have also been a few hours ago. And because "just now" is really 15 ago at max, this is a change that should be made.

Alternatively, I'd suggest "gerade eben" as an alternative. Not a huge difference, just longer, but maybe a bit easier to understand. If I had to choose, I'd probably rather go with "gerade".
